### PR TITLE
[figma]:update to 0.6.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aim-vue-icon",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Aim Vue Icon, Automation workflow with Figma",
   "main": "bundle/index.common.js",
   "files": [


### PR DESCRIPTION
更新了找不到6位编码使用占位图标的规则